### PR TITLE
mvn deploy only on push

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -8,6 +8,7 @@ on:
     branches: [ develop ]
   pull_request:
     branches: [ develop ]
+    types: [ opened, reopened ]
 
 jobs:
   build:
@@ -32,6 +33,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ github.token }}
     - name: Publish to GitHub Packages Apache Maven
+      if: github.event_name == 'push'
       run: mvn deploy --file dpppt-backend-sdk/pom.xml -s $GITHUB_WORKSPACE/settings.xml
       env:
         GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
This pull request solves the issue #8. 
I added a condition on the deploy action to execute it only on push.
Moreover I added the types `[open, reopened]` on `pull_request`, to avoid running the workflow twice on merged pull requests (on` pull_request.closed` and then on `push`)