### PR TITLE
added dev-run and dev-stop goals to do one command build and run for …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,16 @@ all1: clean updateproject swagger la la2 la3
 no: clean updateproject swagger la la2 
 docker-build: updateproject docker
 
+help: 
+	@awk 'BEGIN {FS = ":.*##"; printf " \nnoiapp-backend\n\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
+
+dev-run: docker-build ## Builds and runs containerized server in dev configuration 
+	docker run --rm -d -p 80:8080 -e JAVA_OPTS="-Dspring.profiles.active=dev" --name=dev_noiapp noiapp/noiapp-backend:develop
+
+dev-stop: ## stops the dev server
+	docker stop dev_noiapp
+
 updateproject:
 	mvn -f dpppt-backend-sdk/pom.xml clean package
 	#cp dpppt-backend-sdk/dpppt-backend-sdk-ws/generated/swagger/swagger.yaml documentation/yaml/sdk.yaml
@@ -33,6 +43,7 @@ show:
 
 docker:
 	cp dpppt-backend-sdk/dpppt-backend-sdk-ws/target/dpppt-backend-sdk-ws-1.0.0-SNAPSHOT.jar ws-sdk/ws/bin/dpppt-backend-sdk-ws-1.0.0.jar
+	mkdir -p ws-sdk/ws/conf
 	rm -f ws-sdk/ws/conf/*
 	cp dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/resources/logback.xml ws-sdk/ws/conf/dpppt-backend-sdk-ws-logback.xml
 	cp dpppt-backend-sdk/dpppt-backend-sdk-ws/src/main/resources/*.properties ws-sdk/ws/conf


### PR DESCRIPTION
questa PR permette di ovviare al problema riscontrato alla prima build del progetto, ossia la mancanza della directory /ws/conf nella quale il processo di inizializzazione della build docker copiava alcuni file necessari. Ho aggiunto inoltre dei target make (e relativo) help per velocizzare il processo di build. Ho testato l'utilizzo di questi target sia partendo dallo stato iniziale che ripetendo due build. 

Grazie a queste modifiche intendo migliorare la developer experience, credo che possa aiutare nuovi contributors ad "appassionarsi" al progetto